### PR TITLE
AlternateMerge: removed duplicate return statements

### DIFF
--- a/DSA Essentials Solutions/Backtracking/permutations.cpp
+++ b/DSA Essentials Solutions/Backtracking/permutations.cpp
@@ -1,0 +1,25 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+void permutation(string &str, vector<string> &result, int itr, int size)
+{
+    // base case
+    if (itr == size)
+    {
+        // storing result 
+        result.push_back(str);
+        return;
+    }
+
+    for (int i = itr; i < size; i++)
+    {
+        // work
+        swap(str[i], str[itr]);
+
+        // recursive call
+        permutation(str, result, itr + 1, size);
+
+        // backtracking
+        swap(str[i], str[itr]);
+    }
+}

--- a/DSA Essentials Solutions/Linked List/AlternateMerge.cpp
+++ b/DSA Essentials Solutions/Linked List/AlternateMerge.cpp
@@ -48,8 +48,7 @@ node* alternateMerge(node * root1, node* root2){
             root2 = root2->next;
         }
     }
-    if(!root1) return root2;
-    if(!root2) return root1;
+
     return root;
 }
 


### PR DESCRIPTION
Removed two duplicate return statements from lines 51 and 52, which is already present on lines 31 and 32.