### PR TITLE
Prefix Strings (Trie): Removing lines of code that resulted duplicates

### DIFF
--- a/DSA Essentials Solutions/Trie/PrefixStrings.cpp
+++ b/DSA Essentials Solutions/Trie/PrefixStrings.cpp
@@ -1,80 +1,86 @@
 #include <bits/stdc++.h>
 using namespace std;
 
-class node{
-    public:
+class node
+{
+public:
     char ch;
-    unordered_map<char,node*> next;
+    unordered_map<char, node *> next;
     bool isTerminal;
-    node(char a){
-        ch=a;
-        bool isTerminal=false;
+    node(char a)
+    {
+        ch = a;
+        bool isTerminal = false;
     }
 };
-class Trie{
-    public:
-    node*root= new node('\0');
-    
-    void insert(string str){
+class Trie
+{
+public:
+    node *root = new node('\0');
 
-        node*temp=root;
-        for(int i=0; i<str.length(); i++){
-           if(temp->next.count(str[i])==0){
-               temp->next[str[i]]=new node(str[i]);
-           }
-           temp=temp->next[str[i]];
+    void insert(string str)
+    {
+
+        node *temp = root;
+        for (int i = 0; i < str.length(); i++)
+        {
+            if (temp->next.count(str[i]) == 0)
+            {
+                temp->next[str[i]] = new node(str[i]);
+            }
+            temp = temp->next[str[i]];
         }
-        temp->isTerminal=true;
+        temp->isTerminal = true;
         return;
     }
-    void dfs(node*temp, vector<string> &v, string word ){
-        if(temp->isTerminal){
+
+    void dfs(node *temp, vector<string> &v, string word)
+    {
+        if (temp->isTerminal)
+        {
             v.push_back(word);
         }
-        if(temp->next.empty()){
+        if (temp->next.empty())
+        {
             return;
         }
-        for(auto p:temp->next){
-          word.push_back(p.first);
-          dfs(temp->next[p.first],v,word);
-          word.pop_back();
+        for (auto p : temp->next)
+        {
+            word.push_back(p.first);
+            dfs(temp->next[p.first], v, word);
+            word.pop_back();
         }
         return;
     }
 
-    
-
-    vector<string> find(string str){
+    vector<string> find(string str)
+    {
         vector<string> v;
-        node* temp=root;
-        string word="";
-        for(int i=0; i<str.length(); i++){
-           if(temp->next.count(str[i])==0){
-               return v;
-           }
-           word.push_back(str[i]);
-           temp=temp->next[str[i]];
+        node *temp = root;
+        string word = "";
+        for (int i = 0; i < str.length(); i++)
+        {
+            if (temp->next.count(str[i]) == 0)
+            {
+                return v;
+            }
+            word.push_back(str[i]);
+            temp = temp->next[str[i]];
         }
-        if(temp->isTerminal){
-            v.push_back(word);
-        }
-        dfs(temp,v,word);
-        sort(v.begin(),v.end());
+
+        dfs(temp, v, word);
+        sort(v.begin(), v.end());
         return v;
     }
-
-    
-    
-
 };
 
-
-
-vector<string> findPrefixStrings(vector<string> words, string prefix){
-        Trie t;
-        for(auto s:words){
-            t.insert(s);
-        }
-        vector<string> res=t.find(prefix);
-        return res;
+vector<string> findPrefixStrings(vector<string> words, string prefix)
+{
+    Trie t;
+    for (auto s : words)
+    {
+        t.insert(s);
     }
+    vector<string> res = t.find(prefix);
+    return res;
+}


### PR DESCRIPTION
The solution provided in the GitHub repo might need some correction!

we have a **dfs function**, which has a case for handling the current node isTerminal and if it is terminal, then we're adding the word in the vector that contains our result.

we have a **find function** that checks whether our tree contains the prefix; if it does, then it calls the dfs function and passes args (address of the last prefix char, address of vector, and word, i.e., the prefix itself)

In the find function, we have also added a check before calling the dfs; if temp/curr is a Terminal, then add it to the vector. _line 58-60_



**Conclusion:** There were two checks for the same purpose, and if we pass the same temp, it will repeat the string in the result vector.

**Case:** if the prefix is also present in the vector<string> word.

**Fix:** Please remove lines 58-60 or _merge my pull request_